### PR TITLE
add python 3.6 to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - PYTHON_VERSION: 2.7
     - PYTHON_VERSION: 3.4
     - PYTHON_VERSION: 3.5
+    - PYTHON_VERSION: 3.6
 
 install:
 - wget https://raw.githubusercontent.com/menpo/condaci/v0.4.x/condaci.py -O condaci.py


### PR DESCRIPTION
Python 3.6 is the default python version for the anaconda installs.