### PR TITLE
do not remove build directories so cmake can still find the libs

### DIFF
--- a/conda/bld.bat
+++ b/conda/bld.bat
@@ -80,8 +80,6 @@ if %ERRORLEVEL% GEQ 8 exit 1
 
 RD /S /Q "%LIBRARY_PREFIX%\bin\Release"
 RD /S /Q "%LIBRARY_PREFIX%\bin\Debug"
-RD /S /Q "%LIBRARY_PREFIX%\x64"
-RD /S /Q "%LIBRARY_PREFIX%\x86"
 RD /S /Q "%SRC_DIR%\opencv_contrib"
 exit 0
 


### PR DESCRIPTION
Fix for #23. The cmake files generated by the opencv build system assume the directories as created by the cmake build. We should therefore not remove them.

@patricksnape 